### PR TITLE
ifluatex and ifxelatex are now a part of iftex

### DIFF
--- a/Makefile_Latex
+++ b/Makefile_Latex
@@ -33,7 +33,7 @@ $(TLMGR): $(TEXLIVE_SOURCE) $(WGET) $(MD5_pm)
 pandoc-packages: $(TLMGR)
 	$(TLMGR) install \
 		xcolor amsfonts amsmath lm unicode-math \
-		ifxetex ifluatex listings fancyvrb booktabs \
+		iftex listings fancyvrb booktabs \
 		hyperref ulem geometry setspace babel upquote \
 		microtype parskip xurl oberdiek tools \
 		graphics footnotehyper mdwtools etoolbox ec


### PR DESCRIPTION
Packages ifluatex and ifxelatex are now a part of iftex. It seems you can't download ifxelatex by tlmgr now.
https://tex.stackexchange.com/a/532032